### PR TITLE
Fix some small end of game bugs

### DIFF
--- a/game.c
+++ b/game.c
@@ -49,6 +49,8 @@ uint8_t     overlay_order[MAX_OVERLAYS];
 // Do we need to reload the files on newgame?
 bool        game_restart = false;
 uint8_t     nb_animations = 0;
+uint8_t     nb_escaped = 0;
+
 s_animation animations[MAX_ANIMATIONS];
 s_guybrush  guybrush[NB_GUYBRUSHES];
 
@@ -455,6 +457,7 @@ void newgame_init()
         for (j=0; j<CMP_MAP_HEIGHT; j++)
             remove_props[i][j] = 0;
 
+    nb_escaped = 0;
 
     // Setup the start time
     hours_digit_h = 0;
@@ -575,6 +578,11 @@ bool load_game(char* load_name)
     for (i=0; i<CMP_MAP_WIDTH; i++)
         for (j=0; j<CMP_MAP_HEIGHT; j++)
             remove_props[i][j] = 0;
+
+    nb_escaped = 0;
+    for (i = 0; i < NB_NATIONS; i++)
+        if (p_event[i].escaped)
+            ++nb_escaped;
 
     // Restore the palette
     to_16bit_palette(palette_index, 0xFF, PALETTES);
@@ -2779,7 +2787,6 @@ void require_pass(uint32_t p)
 // Have a look at what our prisoner are doing
 void check_on_prisoners()
 {
-    static int nb_escaped = 0;
     int p;
     uint16_t i;
     uint16_t authorized_id;
@@ -2822,7 +2829,8 @@ void check_on_prisoners()
         if (p_event[p].escaped)
             game_won_count++;
     }
-    if (game_over_count == NB_NATIONS)
+
+    if (game_over_count == NB_NATIONS || (game_over_count > 0 && (game_over_count + game_won_count >= NB_NATIONS)))
     {
         game_state = GAME_STATE_GAME_OVER;
         static_screen(GAME_OVER_TEXT, NULL, 0);

--- a/game.c
+++ b/game.c
@@ -2793,6 +2793,7 @@ void check_on_prisoners()
     {
         if (props[current_nation][ITEM_PAPERS])
         {
+            p_event[current_nation].escaped = true;
             nb_escaped++;
             if (nb_escaped >= NB_NATIONS)
             {
@@ -2801,7 +2802,6 @@ void check_on_prisoners()
             else
             {
                 static_screen(PRISONER_FREE, NULL, 0);
-                p_event[current_nation].escaped = true;
             }
         }
         else

--- a/game.h
+++ b/game.h
@@ -122,9 +122,9 @@ static __inline void consume_prop()
  *	Global variables
  */
 extern uint8_t		nb_animations;
+extern uint8_t      nb_escaped;
 extern s_animation	animations[MAX_ANIMATIONS];
 extern s_guybrush	guybrush[NB_GUYBRUSHES];
-
 
 /*
  *	Public prototypes


### PR DESCRIPTION
Hey,
Finally escaped from the castle this morning (33 years? 😄) and found a couple of small issues at the end of the game.

- Fix an issue when all players escape, the end pub image was not displaying with the music (game was stuck in a loop between game screen and 'congrats all escaped' screen)
- Fix issue when 1 prisoner had escaped, and others where in solitary/had died, the game wouldn't end
- Fix issue when loading a game or starting a new game, nb_escaped wasn't reset, so having 1 player escape would cause the game to end
